### PR TITLE
Add raw monitoring tables to dbt pipeline

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -39,5 +39,9 @@ models:
     final:
       schema: "final"
       +materialized: table
-      
+
+    raw:
+      schema: "raw"
+      +materialized: table
+  
 

--- a/models/raw/student_assignment.sql
+++ b/models/raw/student_assignment.sql
@@ -1,0 +1,68 @@
+{{ config(
+    materialized = 'incremental',
+    incremental_strategy = 'delete+insert',
+    unique_key = ['student_id', 'resource_id', 'submitted_at']
+) }}
+
+WITH raw_student_cohort_data AS (
+    SELECT
+        student_id,
+        cohort_code
+    FROM {{ source('raw', 'student_cohort') }}
+),
+
+student_details_data AS (
+    SELECT id,email FROM raw.student_details
+),
+
+assignment_data AS (
+    SELECT
+        assignment_name AS name,
+        "Email" AS email,
+        student_name,
+        submission_status,
+        feedback_comments AS feedback,
+        submitted_at,
+        assignment_file
+    FROM {{ source('old', 'assignment_monitoring_data') }}
+),
+
+resource_data AS (
+    SELECT
+        id AS resource_id,
+        title
+    FROM {{ source('raw', 'resource') }}
+    WHERE category = 'Assignment'
+),
+
+student_assignment_data AS (
+    SELECT
+        sd.id::INT AS student_id,
+        r.resource_id::INT AS resource_id,
+        NULL::INT AS mentor_id,
+        sc.cohort_code,
+        a.submission_status::raw.submission_status_enum AS submission_status,
+        CASE 
+            WHEN a.submission_status = 'under review' THEN 30
+            WHEN a.submission_status = 'reviewed' THEN 100
+            WHEN a.submission_status = 'rejected' THEN 80
+            ELSE 0
+        END::DECIMAL AS marks_pct,
+        a.feedback AS feedback_comments,
+        NULLIF(TRIM(a.submitted_at), '')::timestamp AS submitted_at,
+        a.assignment_file
+    FROM assignment_data a
+    INNER JOIN student_details_data sd
+        ON a.email = sd.email
+    INNER JOIN raw_student_cohort_data sc
+        ON sd.id = sc.student_id
+    INNER JOIN resource_data r
+        ON a.name = r.title
+    WHERE TRIM(a.submitted_at) IS NOT NULL
+      AND TRIM(a.submitted_at) <> ''
+      AND TRIM(a.submitted_at) <> 'NaN'
+)
+
+SELECT *
+FROM student_assignment_data
+WHERE cohort_code IN ('INC007','INC008','INC009')    --Change as per cohorts that needs to be updated, will reduce runtime.  

--- a/models/raw/student_pre_recorded.sql
+++ b/models/raw/student_pre_recorded.sql
@@ -1,0 +1,44 @@
+{{ config(
+    materialized = 'incremental',
+    incremental_strategy = 'delete+insert',
+    unique_key = ['student_id', 'resource_id']
+) }}
+
+
+WITH raw_student_cohort_data AS (
+    SELECT student_id, cohort_code
+    FROM raw.student_cohort
+),
+student_details_data AS (
+    SELECT id,email FROM raw.student_details
+),
+resource_data AS (
+    SELECT id AS resource_id, title, total_duration AS watchtime_in_min
+    FROM raw.resource
+),
+raw_student_session_info AS (
+    SELECT
+        "Email" AS email,
+        "Session_Code" AS session_code,
+        "Duration_in_secs" AS watchtime_in_secs,
+        "watched_on" AS watched_on
+    FROM old.student_session_information
+    WHERE "Session_Code" LIKE 'VID%'
+           
+),
+student_pre_recorded_cte AS (
+    SELECT
+        sd.id::INT AS student_id,
+        r.resource_id::INT AS resource_id,
+        sc.cohort_code AS cohort_code,
+        ssi.watchtime_in_secs::INT AS watchtime_in_sec,
+        ssi.watched_on::DATE AS watched_at
+    FROM raw_student_session_info ssi
+    INNER JOIN student_details_data sd ON ssi.email = sd.email                    
+    INNER JOIN raw_student_cohort_data sc ON sd.id = sc.student_id
+    INNER JOIN resource_data r ON ssi.session_code = r.title
+)
+
+SELECT *
+FROM student_pre_recorded_cte
+WHERE cohort_code IN ('INC007','INC008','INC009')   --Change as per cohorts that needs to be updated, will reduce runtime.  

--- a/models/raw/student_quiz.sql
+++ b/models/raw/student_quiz.sql
@@ -1,0 +1,44 @@
+{{ config(
+    materialized = 'incremental',
+    incremental_strategy = 'delete+insert',
+    unique_key = ['student_id', 'resource_id']
+) }}
+
+WITH raw_student_cohort_data AS (
+    SELECT student_id, cohort_code
+    FROM raw.student_cohort
+),
+quiz_data AS (
+    SELECT
+        "user_id" AS email,
+        "data_fields" AS quiz_name,
+        "value" AS obtained_marks
+    FROM old.incubator_quiz_monitoring
+),
+                          
+student_details_data AS (
+    SELECT id,email FROM raw.student_details
+),
+resource_data AS (
+    SELECT id AS resource_id, title
+    FROM raw.resource
+    WHERE category = 'Quiz'
+),
+student_quiz_data AS (
+    SELECT
+        sd.id::INT AS student_id,
+        r.resource_id::INT AS resource_id,
+        sc.cohort_code AS cohort_code,
+        100::INT AS max_marks,
+        q.obtained_marks::INT AS marks,
+        NULL::INT AS reattempts,
+        NULL::TIMESTAMP AS attempted_at
+    FROM quiz_data q
+    INNER JOIN student_details_data sd ON q.email = sd.email                    
+    INNER JOIN raw_student_cohort_data sc ON sd.id = sc.student_id
+    INNER JOIN resource_data r ON q.quiz_name = r.title
+)
+
+SELECT *
+FROM student_quiz_data
+WHERE cohort_code IN ('INC007')  --Change as per cohorts that needs to be updated, will reduce runtime. 

--- a/models/raw/student_session.sql
+++ b/models/raw/student_session.sql
@@ -1,0 +1,45 @@
+{{ config(
+    materialized = 'incremental',
+    incremental_strategy = 'delete+insert',
+    unique_key = ['student_id', 'session_id']
+) }}
+
+WITH raw_student_cohort_data AS (
+    SELECT student_id, cohort_code
+    FROM raw.student_cohort
+),
+student_details_data AS (
+    SELECT id,email FROM raw.student_details
+),
+session_data AS (
+    SELECT id AS session_id, session_name, cohort_code, code
+    FROM raw.live_session
+),
+raw_student_session_info AS (
+    SELECT
+        "Email" AS email,
+        "Session_Code" AS session_code,
+        "Duration_in_secs" AS duration_in_sec,
+        "watched_on" AS watched_on
+    FROM old.student_session_information
+    WHERE "Session_Code" LIKE 'SUK%' 
+        OR "Session_Code" LIKE 'WS%'      
+        OR "Session_Code" LIKE 'MC%'
+),
+student_live_session_cte AS (
+    SELECT
+        sd.id::INT AS student_id,
+        s.session_id::INT AS session_id,
+        ssi.duration_in_sec::INT AS duration_in_sec,
+        ssi.watched_on::DATE AS watched_on
+    FROM raw_student_session_info ssi
+    INNER JOIN student_details_data sd ON ssi.email = sd.email                    
+    INNER JOIN raw_student_cohort_data sc ON sd.id = sc.student_id
+    INNER JOIN session_data s ON ssi.session_code = s.code AND sc.cohort_code = s.cohort_code
+)
+
+SELECT sls.*
+FROM student_live_session_cte sls
+INNER JOIN raw_student_cohort_data sc 
+    ON sls.student_id = sc.student_id
+WHERE sc.cohort_code IN ('INC007')   --Change as per cohorts that needs to be updated, will reduce runtime.  

--- a/models/sources.yml
+++ b/models/sources.yml
@@ -40,4 +40,5 @@ sources:
         description: "standardised file for subjects data"
       - name: university_mapping
         description: "standardised file for universities data"
-      # Add all raw schema's tables here.
+      - name: student_cohort
+        description: "student cohort mapping details"


### PR DESCRIPTION
Changes Made:

Added the raw monitoring table models under the raw folder:

**student_assignment** – Stores each student’s assignment submissions, linked to the assignment (resource_id), mentor, and their cohort_code.
**student_quiz** – Stores quiz attempt records for each student, linked to the quiz (resource_id) and their cohort_code.
**student_pre_recorded** – Stores how much time each student watched pre-recorded videos, linked to the video (resource_id) and their cohort_code.
**student_session** – Stores students’ live session attendance, linked to the cohort wise live session(session_id) .

Linked Issue:
Closes #11